### PR TITLE
Updates to Version 2.12.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
 target 'hello-macos' do
     platform :osx, '10.10'
-    pod 'LaunchDarkly', '2.11.1'
+    pod 'LaunchDarkly', '2.12.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - DarklyEventSource (3.2.0)
-  - LaunchDarkly (2.11.1):
-    - LaunchDarkly/Core (= 2.11.1)
-  - LaunchDarkly/Core (2.11.1):
-    - DarklyEventSource (~> 3.2.0)
+  - DarklyEventSource (3.2.3)
+  - LaunchDarkly (2.12.0):
+    - LaunchDarkly/Core (= 2.12.0)
+  - LaunchDarkly/Core (2.12.0):
+    - DarklyEventSource (~> 3.2.3)
 
 DEPENDENCIES:
-  - LaunchDarkly (= 2.11.1)
+  - LaunchDarkly (= 2.12.0)
 
 SPEC CHECKSUMS:
-  DarklyEventSource: ad6a75c82b22bea91c75fc980a563f6d2902ce90
-  LaunchDarkly: 830b9e6ee4d8e29162395296fcc176704402445e
+  DarklyEventSource: d5c8e000988ee1feac6c3ffa3dcbdfbaca10d444
+  LaunchDarkly: 5339926c68b711dde38b1689d645b20a56cbbfc2
 
-PODFILE CHECKSUM: e7578e96c65e557767bdbd8feeca9eb89c306e95
+PODFILE CHECKSUM: 290e83cf31725e00ab29312850f9eda443af0da0
 
 COCOAPODS: 1.4.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - echo "No tests are defined for hello-macos."

--- a/hello-macos.xcodeproj/project.pbxproj
+++ b/hello-macos.xcodeproj/project.pbxproj
@@ -129,8 +129,8 @@
 				690AFE781E9D1E4D00174601 /* Sources */,
 				690AFE791E9D1E4D00174601 /* Frameworks */,
 				690AFE7A1E9D1E4D00174601 /* Resources */,
-				66BF38D0D14E5B51AF090852 /* [CP] Embed Pods Frameworks */,
-				27714B093BF99B66C90A7511 /* [CP] Copy Pods Resources */,
+				1FA482019457CCB347F85A23 /* [CP] Embed Pods Frameworks */,
+				4C5E57AF864D3D253E7C3D30 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -220,19 +220,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		27714B093BF99B66C90A7511 /* [CP] Copy Pods Resources */ = {
+		1FA482019457CCB347F85A23 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-hello-macos/Pods-hello-macos-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-hello-macos/Pods-hello-macos-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3DDEDAF1207EA269E449E7BB /* [CP] Check Pods Manifest.lock */ = {
@@ -253,19 +253,19 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		66BF38D0D14E5B51AF090852 /* [CP] Embed Pods Frameworks */ = {
+		4C5E57AF864D3D253E7C3D30 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-hello-macos/Pods-hello-macos-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-hello-macos/Pods-hello-macos-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
also clears circleCI failures due to no tests