### PR TITLE
chore: Update iOS Client SDK resolved version from 11.1.1 to 11.1.2

### DIFF
--- a/hello-macos.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hello-macos.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/ios-client-sdk.git",
       "state" : {
-        "revision" : "8b56cf8a7f74618a5d8e9ef0e4dad543e2f3fed7",
-        "version" : "11.1.1"
+        "revision" : "34fcbc00251ed5890d26d7d859c3c1385a684030",
+        "version" : "11.1.2"
       }
     },
     {


### PR DESCRIPTION
## Summary
Bumps the resolved `ios-client-sdk` SPM dependency from 11.1.1 to 11.1.2 (patch release) in `Package.resolved`. The `project.pbxproj` version constraint (`upToNextMajorVersion` from 11.0.0) is unchanged and already permits this version.

## Review & Testing Checklist for Human
- [ ] Verify the commit SHA `34fcbc00251ed5890d26d7d859c3c1385a684030` actually corresponds to the `11.1.2` tag on [launchdarkly/ios-client-sdk](https://github.com/launchdarkly/ios-client-sdk/releases/tag/11.1.2) — the resolved file was updated manually, not via Xcode's package resolution
- [ ] Open `hello-macos.xcworkspace` in Xcode, let SPM resolve, and confirm the project builds and runs successfully

### Notes
- Only the lock file (`Package.resolved`) is changed; no source code or project configuration changes
- The `swift-eventsource` pin remains at 3.3.0 — confirm this is still compatible with ios-client-sdk 11.1.2

Link to Devin session: https://app.devin.ai/sessions/707962703f2540d5b8c92734ecf9e33a
Requested by: @kinyoklion