### PR TITLE
chore: update iOS SDK to 11.1.3 in Package.resolved

### DIFF
--- a/hello-macos.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hello-macos.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/ios-client-sdk.git",
       "state" : {
-        "revision" : "34fcbc00251ed5890d26d7d859c3c1385a684030",
-        "version" : "11.1.2"
+        "revision" : "93c519e2aeb12f61faaddf9c77a646ec9b4c3049",
+        "version" : "11.1.3"
       }
     },
     {


### PR DESCRIPTION
## Summary
Update the iOS/macOS client SDK from 11.1.2 to 11.1.3 in the SPM Package.resolved lockfile.

The SPM version requirement (`upToNextMajorVersion` from `11.0.0`) already allows this version. This updates the resolved lockfile to pin to the latest patch release.

## Review & Testing Checklist for Human
- [ ] Open the project in Xcode and verify it builds and runs on macOS

### Notes
The `swift-eventsource` dependency is already at the latest version (3.3.0).

Link to Devin session: https://app.devin.ai/sessions/b648d8cd5e0b4a04ba0cbf1dcd1a9886
Requested by: @kinyoklion