### PR TITLE
chore: update ios-client-sdk from 11.1.3 to 11.2.0

### DIFF
--- a/hello-macos.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/hello-macos.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/ios-client-sdk.git",
       "state" : {
-        "revision" : "93c519e2aeb12f61faaddf9c77a646ec9b4c3049",
-        "version" : "11.1.3"
+        "revision" : "0edfeefdaf493b64f4604e4b247b56b309311cd9",
+        "version" : "11.2.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

Updates the SPM `Package.resolved` pin for `ios-client-sdk` from 11.1.3 to 11.2.0.

Link to Devin session: https://app.devin.ai/sessions/d0545f9be7594100bb281ceb0584d2ae
Requested by: @kinyoklion